### PR TITLE
Fixing "too many arguments" error when installing openvpn on Bionic

### DIFF
--- a/packages/openvpn/packaging
+++ b/packages/openvpn/packaging
@@ -5,7 +5,7 @@ set -u
 
 cpus=$( grep -c ^processor /proc/cpuinfo )
 
-OPENSSL_VERSION = openssl-*
+OPENSSL_VERSION=$(ls openssl-*.tar.gz | awk -F. '{print $1}')
 ( cd openssl
 
   tar -xzf ${OPENSSL_VERSION}.tar.gz
@@ -21,7 +21,7 @@ OPENSSL_VERSION = openssl-*
   make install
 )
 
-LZO_VERSION = lzo-*
+LZO_VERSION = $(ls lzo-*.tar.gz | awk -F. '{print $1}')
 ( cd lzo
 
   tar -xzf ${LZO_VERSION}.tar.gz
@@ -34,7 +34,7 @@ LZO_VERSION = lzo-*
   make install
 )
 
-OPENVPN_VERSION = openvpn-*
+OPENVPN_VERSION = $(ls openvpn-*.tar.gz | awk -F. '{print $1}')
 ( cd openvpn
 
   tar -xzf ${OPENVPN_VERSION}.tar.gz

--- a/packages/openvpn/packaging
+++ b/packages/openvpn/packaging
@@ -21,7 +21,7 @@ OPENSSL_VERSION=$(ls openssl-*.tar.gz | awk -F. '{print $1}')
   make install
 )
 
-LZO_VERSION = $(ls lzo-*.tar.gz | awk -F. '{print $1}')
+LZO_VERSION=$(ls lzo-*.tar.gz | awk -F. '{print $1}')
 ( cd lzo
 
   tar -xzf ${LZO_VERSION}.tar.gz
@@ -34,7 +34,7 @@ LZO_VERSION = $(ls lzo-*.tar.gz | awk -F. '{print $1}')
   make install
 )
 
-OPENVPN_VERSION = $(ls openvpn-*.tar.gz | awk -F. '{print $1}')
+OPENVPN_VERSION=$(ls openvpn-*.tar.gz | awk -F. '{print $1}')
 ( cd openvpn
 
   tar -xzf ${OPENVPN_VERSION}.tar.gz


### PR DESCRIPTION
When packaging under Bionic the directory change using a wildcard results in an error since it matches both the .tar.gz file as well as the newly created directory.